### PR TITLE
Fix altitude callouts

### DIFF
--- a/source/instrumentation.cs
+++ b/source/instrumentation.cs
@@ -917,7 +917,7 @@ namespace tfm
 
             for (int i = 1000; i < 65000; i += 1000)
             {
-                if (alt >= i-10 && alt <= i-10 && altitudeCalloutFlags[i] == false)
+                if (alt >= i-10 && alt <= i+10 && altitudeCalloutFlags[i] == false)
                 {
                     fireOnScreenReaderOutputEvent(isGauge:false, output:$"{i} feet. ");
                     altitudeCalloutFlags[i] = true;


### PR DESCRIPTION
Fixed a logic error that would have made altitude callouts
not work correctly. This was
due to a minus sign being used where a plus should have gone.